### PR TITLE
Elevation lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,39 @@
 # gpsrenda: simple open-source GPS statistics video overlay renderer
 
-`gpsrenda` is a video overlay renderer that takes statistics from a FIT
-file, and renders gauges on top of video captured by a GoPro.  It uses Cairo
-to do all its graphics rendering, and Gstreamer as a video backend.  It takes
-its configuration programmatically, and is designed to be (relatively)
-simple, hackable, and extensible (at least, if you think that using Python
-as a configuration language without having a GUI at all is simple).  It
-competes with DashWare and Garmin VIRB (with the hope that it's easier to
-automate than DashWare, and more flexible than VIRB).
+`gpsrenda` is a video overlay renderer that takes statistics from a FIT file, and renders gauges on top of video
+captured during the activity using e.g. a GoPro. It uses Cairo to do all its graphics rendering, and `moviepy` as a
+video backend. It is designed to be (relatively) simple, hackable, and extensible. It competes with DashWare and Garmin
+VIRB (with the hope that it's easier to automate than DashWare, and more turnkey than VIRB).
 
-I have it tested with a GoPro Hero 8 Black, and a Wahoo ELEMNT BOLT.  To get
-the best use of it, hit the start button on the GPS *with the GoPro
-running*, and then use the GPS start sound in the video to synchronize the
-time offset between the GPS data and the video.
+## Installation
 
-I've successfully fed the output to `kdenlive`, which is extremely slow at
-rendering... I'll try other non-linear video editors next.
+```sh
+git clone git@github.com:jwise/gpsrenda.git
+cd gpsrenda
+pip install .
+```
 
-## Setup
+`gpsrenda` should work with system, pyenv/pip, and Anaconda-based Python installations. On Windows only Anaconda has
+been tested due to `cairo` being tricky on Windows systems.
 
-You need a handful of Python packages installed, including `cairo`,
-`fitparse`, and the PyGObject bridge for Gst (on my Ubuntu machine, the
-package is called `python3-gst-1.0`).  For a usage example, check out
-`sample.py`, which generates output that looks as below:
+## Usage
+
+`renda --help` for full usage information. Point to the example config file at `example_config.yml` for an example that
+should look roughly like this:
 
 ![an example image generated with gpsrenda](sample.jpg)
 
+## Synchronization
+
+One trick you may find helpful is to hit the start button on the GPS *with the GoPro running*, and then use the GPS
+start sound in the video to synchronize the time offset between the GPS data and the video. Alternatively, you can use
+the `--preview` flag to render a preview with no time offset, and infer the time offset from the overlay. Finally, you
+may even find it helpful to use Virb's excellent map-based side-by-side synchronization tool to determine the time
+offset before doing your actual overlay here.
+
+You can then use the `-t` flag to provide the time offset to the renderer.
+
+## Hardware
+
+We have tested `gpsrenda` with a GoPro Hero 8 Black + Wahoo ELEMNT BOLT as well as a GoPro Hero 7 Silver + Garmin Edge
+530.

--- a/example_conf.yml
+++ b/example_conf.yml
@@ -1,3 +1,9 @@
+data:
+  altitude:
+    lag: 0
+  grade:
+    averaging_time: 2
+
 widgets:
   - type: Speed
     style: hbar

--- a/flgr_conf.yml
+++ b/flgr_conf.yml
@@ -1,3 +1,9 @@
+data:
+  altitude:
+    lag: 25
+  grade:
+    averaging_time: 4
+
 widgets:
   - type: Speed
     style: hbar

--- a/gpsrenda/scripts/renda
+++ b/gpsrenda/scripts/renda
@@ -22,10 +22,10 @@ def renda(video_paths, data_path, time_offset, config_path, preview):
     logger.setLevel(logging.DEBUG)
     logger.debug("Begin")
 
-    data_source = FitDataSource(data_path)
-
     with open(config_path, 'r') as config_file:
         config_data = yaml.safe_load(config_file)
+
+    data_source = FitDataSource(data_path, config=config_data['data'])
 
     widgets = []
     widget_module = import_module('gpsrenda.widgets.widgets')
@@ -78,6 +78,7 @@ def renda(video_paths, data_path, time_offset, config_path, preview):
             composite_clip.write_videofile(
                 output_file,
                 fps=clip.fps,
+                audio_codec='aac',
                 threads=None,
                 ffmpeg_params=[
                     '-crf', '30',

--- a/gpsrenda/utils.py
+++ b/gpsrenda/utils.py
@@ -37,3 +37,26 @@ def c_to_f(c):
 
 def m_to_ft(m):
     return m * 3.2808399
+
+def merge_dict(dct, merge_dct):
+    """Recursive dict merge. Inspired by ``dict.update()``, instead of
+    updating only top-level keys, dict_merge recurses down into dicts nested
+    to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
+    ``dct``.
+
+    Args:
+        dct: dict onto which the merge is executed
+        merge_dct: dct merged into dct
+
+    Returns dct after the merge.
+    """
+    import collections
+
+    for k, v in merge_dct.items():
+        if (k in dct and isinstance(dct[k], dict)
+                and isinstance(merge_dct[k], collections.Mapping)):
+            merge_dict(dct[k], merge_dct[k])
+        else:
+            dct[k] = merge_dct[k]
+
+    return dct


### PR DESCRIPTION
Garmins have a bad habit of logging very stale altitude data, with a lag of 10-30 seconds. This fix allows you to compensate for that with config file settings, and also fixes up some odds and ends in the readme and configs.